### PR TITLE
Callout network protocol impact on carbon intensity

### DIFF
--- a/src/principles/networking.md
+++ b/src/principles/networking.md
@@ -17,3 +17,4 @@ The amount of carbon emitted to send data depends on many factors including:
 *   The number of hops between network devices
 *   The energy efficiency of the network devices
 *   The carbon intensity of energy in the region of each device at the time the data is transmitted.
+*   The network protocol used to coordinate data transmission - e.g. multiplex, header compression, TLS/Quic


### PR DESCRIPTION
- Carbon intensity is impacted by HTTP/1, HTTP/2, and upcoming HTTP/3. The [ability to reduce the frequency of and number of connections via HTTP/2](https://http2.akamai.com/) using multiplexing (parallel transmissions) instead of HTTP/1 traditional TCP 
- [Domain Sharding is no longer required with HTTP/2](https://love2dev.com/blog/domain-sharding-http-2/) - reducing the number of connections to origin & CDN edge nodes reduces the carbon intensity
- [Quic leverages UDP with TCP fallback](https://www.chromium.org/quic) and is a #green-network-protocol as it reduces the multiple required TCP handshakes for TLS and uses a single handshake for secure packet transmission. [Quic also better handles network switch events](https://en.wikipedia.org/wiki/QUIC#Characteristics) (wifi to cellular, etc.) using a connectionID and avoids resending data packets to further reduce carbon intensity