### PR TITLE
Add twitter:card meta tag for bigger summary image

### DIFF
--- a/src/_includes/partials/global/meta-info.njk
+++ b/src/_includes/partials/global/meta-info.njk
@@ -24,6 +24,8 @@
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="{{ currentUrl }}"/>
 
+<meta name="twitter:card" content="summary_large_image">
+
 {% if site.authorHandle %}
   <meta name="twitter:creator" content="@{{ site.authorHandle | replace('@', '') }}"/>
 {% endif %}


### PR DESCRIPTION
Thanks for merging #7, @jawache! Here's a quick addition for a full-size summary card image.  I should have included this in the first PR, but I'm a little rusty on meta tags :) 

Reference: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image