### PR TITLE
Add Spanish to navigation bar and fix template issues

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -24,8 +24,8 @@
       "list": false
     },
     {
-      "text": ["EN","FR"],
-      "url": ["/","/fr-fr"],
+      "text": ["EN","ES","FR"],
+      "url": ["/","/es","/fr-fr"],
       "external": false,
       "list": true
     }

--- a/src/_includes/partials/components/nav.njk
+++ b/src/_includes/partials/components/nav.njk
@@ -1,8 +1,11 @@
-{% if page.url.indexOf("fr-fr") == -1 %}
+{% if page.url.indexOf("fr-fr") == -1 and page.url.indexOf("es") == -1 %}
   {% set language = "" %}
-{% else %}
+{% elif page.url.indexOf("es") == -1 %}
   {% set language = "fr-fr" %}
+{% else %}
+  {% set language = "es" %}
 {% endif %}
+
 {% if navigation.items %}
   <nav class="nav" aria-label="{{ariaLabel}}">
     <ul class="[ nav__list ] [ box-flex align-center md:space-before ]">
@@ -26,9 +29,15 @@
          <li class="nav__item">
           {% if language == "" %}
             <a href="{{ item.url[1] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[1] }}</a>
-          {% else %}
+            <a href="{{ item.url[2] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[2] }}</a>
+          {% elif language == "fr-fr" %}
             <a href="{{ item.url[0] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[0] }}</a>
+            <a href="{{ item.url[1] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[1] }}</a>
+          {% elif language == "es" %}
+            <a href="{{ item.url[0] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[0] }}</a>
+            <a href="{{ item.url[2] }}"{{ relAttribute | safe }}{{ currentAttribute | safe }}>{{ item.text[2] }}</a>
           {% endif %}
+
         </li>
          {% endif %}
       {% endfor %}

--- a/src/es/carbon-intensity.md
+++ b/src/es/carbon-intensity.md
@@ -1,8 +1,10 @@
 ---
+layout: layouts/page.njk
 title: Intensidad de carbono
 summary: Consuma electricidad con la mínima intensidad de carbono
 order: 3
 tags: principle
+language: es
 ---
 
 La intensidad de carbono de la electricidad es una medida de cuantas emisiones de carbono (CO<sub>2</sub>eq) se producen por kilovatio hora de electricidad consumida.

--- a/src/es/carbon.md
+++ b/src/es/carbon.md
@@ -1,8 +1,10 @@
 ---
+layout: layouts/page.njk
 title: Carbono
 summary: Construir aplicaciones que son carbono eficientes
 order: 1
 tags: principio
+language: es
 ---
 
 Los gases de efecto invernadero (GEI) actúan como una manta incrementando la temperatura en la superficie de la Tierra. Este es un efecto natural sin embargo debido a la huella de carbono humana; el clima global está cambiando mucho más rápido de lo que los animales y plantas se pueden adaptar. Cómo se va a adaptar la sociedad humana todavía es una pregunta abierta.

--- a/src/es/demand-shaping.md
+++ b/src/es/demand-shaping.md
@@ -1,8 +1,10 @@
 ---
+layout: layouts/page.njk
 title: Moldeo de la demanda
 summary: Crear aplicaciones que sean conscientes del carbono que emiten.
 order: 7
 tags: principle
+language: es
 ---
 
 <!-- TODO: Definir si desplazamiento de la demanda es apropiado Y cambiar el link al header dentro de carbon-intensity -->
@@ -10,7 +12,7 @@ tags: principle
 
 El moldeo de la demanda es una estrategia similiar, solo que en lugar de mover la demanda a una región o tiempo diferente, la demanda se ajusta para que coincida con el suministro existente.
 
-![alt_text](../assets/images/principles/demand-shaping-1.png "Si la oferta es alta, aumente la demanda; haga más en sus aplicaciones; si la oferta es baja, disminuya la demanda; haga menos en sus aplicaciones.")
+![alt_text](/assets/images/principles/demand-shaping-1.png "Si la oferta es alta, aumente la demanda; haga más en sus aplicaciones; si la oferta es baja, disminuya la demanda; haga menos en sus aplicaciones.")
 
 Un gran ejemplo de esto es el software de videoconferencia. En lugar de transmitir con la mayor calidad posible en todo momento, es posible reducir la demanda al reducir la calidad del video para priorizar el audio.
 

--- a/src/es/electricity.md
+++ b/src/es/electricity.md
@@ -1,4 +1,5 @@
 ---
+layout: layouts/page.njk
 title: Electricidad
 summary: Construyendo aplicaciones con eficiencia de energía
 order: 2

--- a/src/es/embodied-carbon.md
+++ b/src/es/embodied-carbon.md
@@ -1,4 +1,5 @@
 ---
+layout: layouts/page.njk
 title: Carbono incorporado
 summary: Construir aplicaciones que sean eficientes con el hardware
 order: 4

--- a/src/es/energy-proportionality.md
+++ b/src/es/energy-proportionality.md
@@ -1,4 +1,5 @@
 ---
+layout: layouts/page.njk
 title: Proporcionalidad de energía
 summary: Maximizar la eficiencia energética del hardware
 order: 5

--- a/src/es/index.md
+++ b/src/es/index.md
@@ -3,6 +3,7 @@ layout: layouts/page.njk
 title: Principios de la Ingeniería Verde de Software
 summary: Competencias básicas necesarias para definir, construir y ejecutar aplicaciones de software verde sostenibles.
 showCTAButtons: yes
+language: es
 ---
 # Introducción
 

--- a/src/es/measurement.md
+++ b/src/es/measurement.md
@@ -1,4 +1,5 @@
 ---
+layout: layouts/page.njk
 title: Medición y optimización
 summary: Enfocándose en optimizaciones paso a paso que incrementan la eficiencia de carbono en general
 order: 8

--- a/src/es/networking.md
+++ b/src/es/networking.md
@@ -1,4 +1,5 @@
 ---
+layout: layouts/page.njk
 title: Networking
 summary: Reducir la cantidad de datos y la distancia que deben recorrer en la red
 order: 6


### PR DESCRIPTION
I've added Spanish to the navigation bar, the language code is in ISO 639‑1. I've also arranged the languages alphabetically.

There was an issue with an image in the Spanish translations that resulted in a 404 because the asset couldn't be found and didn't compile the page. It should be fixed now.

Also fixed are the lack of templates in many of the Spanish subsections.